### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,12 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["undetected"]
+packages = [
+    "undetected",
+    "undetected/utils",
+    "undetected/inject", 
+    "undetected/inject/js", 
+]
 
 [tool.ruff]
 target-version = "py310"


### PR DESCRIPTION
newly added subdirectories \utils and \inject not considered in wheel